### PR TITLE
Upgrade to seneca 3

### DIFF
--- a/api/api-service.js
+++ b/api/api-service.js
@@ -18,10 +18,9 @@ server.register({
   options:{
     seneca: Seneca({
       tag: 'api',
-      log: 'silent',
+      internal: {logger: require('seneca-demo-logger')},
       debug: {short_logs:true}
     })
-    .use('demo-logger')
   }
 })
 

--- a/api/api-service.js
+++ b/api/api-service.js
@@ -19,7 +19,6 @@ server.register({
     seneca: Seneca({
       tag: 'api',
       log: 'silent',
-      legacy: { logging: false },
       debug: {short_logs:true}
     })
     .use('demo-logger')

--- a/api/api-service.js
+++ b/api/api-service.js
@@ -9,20 +9,20 @@ var Seneca = require('seneca')
 
 var server = new Hapi.Server()
 
-server.connection({ 
+server.connection({
   port: PORT
 })
 
 server.register({
-  register: Chairo, 
+  register: Chairo,
   options:{
     seneca: Seneca({
       tag: 'api',
       log: 'silent',
       legacy: { logging: false },
-      internal: { logger: require('seneca-demo-logger') },
       debug: {short_logs:true}
     })
+    .use('demo-logger')
   }
 })
 
@@ -42,8 +42,8 @@ server.register({
 })
 
 
-server.route({ 
-  method: 'GET', path: '/api/ping', 
+server.route({
+  method: 'GET', path: '/api/ping',
   handler: function( req, reply ){
     server.seneca.act(
       'role:api,cmd:ping',
@@ -53,8 +53,8 @@ server.route({
   )}
 })
 
-server.route({ 
-  method: 'POST', path: '/api/post/{user}', 
+server.route({
+  method: 'POST', path: '/api/post/{user}',
   handler: function( req, reply ){
     server.seneca.act(
       'post:entry',
@@ -67,8 +67,8 @@ server.route({
     )}
 })
 
-server.route({ 
-  method: 'POST', path: '/api/follow/{user}', 
+server.route({
+  method: 'POST', path: '/api/follow/{user}',
   handler: function( req, reply ){
     server.seneca.act(
       'follow:user',

--- a/base/base.js
+++ b/base/base.js
@@ -7,10 +7,9 @@ var BASES = (process.env.BASES || process.argv[4] || '').split(',')
 
 require('seneca')({
   tag: TAG,
-  log: 'silent',
+  internal: {logger: require('seneca-demo-logger')},
   debug: {short_logs:true}
 })
-  .use('demo-logger')
   .use('mesh',{
     isbase: true,
     port: PORT,

--- a/base/base.js
+++ b/base/base.js
@@ -8,7 +8,6 @@ var BASES = (process.env.BASES || process.argv[4] || '').split(',')
 require('seneca')({
   tag: TAG,
   log: 'silent',
-  legacy: { logging: false },
   debug: {short_logs:true}
 })
   .use('demo-logger')

--- a/base/base.js
+++ b/base/base.js
@@ -9,12 +9,12 @@ require('seneca')({
   tag: TAG,
   log: 'silent',
   legacy: { logging: false },
-  internal: { logger: require('seneca-demo-logger') },
   debug: {short_logs:true}
 })
+  .use('demo-logger')
   .use('mesh',{
-    isbase: true, 
-    port: PORT, 
+    isbase: true,
+    port: PORT,
     bases: BASES,
     pin:'role:mesh'
   })

--- a/entry-cache/entry-cache-service.js
+++ b/entry-cache/entry-cache-service.js
@@ -4,11 +4,11 @@ require('seneca')({
   tag:'entry-cache',
   log: 'silent',
   legacy: { logging: false },
-  internal: { logger: require('seneca-demo-logger') },
   debug: {short_logs:true}
 })
+  .use('demo-logger')
   .use('entry-cache-logic')
-  .use('mesh',{ 
+  .use('mesh',{
     pin: 'store:list,kind:entry,cache:*',
     bases: BASES
   })

--- a/entry-cache/entry-cache-service.js
+++ b/entry-cache/entry-cache-service.js
@@ -3,7 +3,6 @@ var BASES = (process.env.BASES || process.argv[2] || '').split(',')
 require('seneca')({
   tag:'entry-cache',
   log: 'silent',
-  legacy: { logging: false },
   debug: {short_logs:true}
 })
   .use('demo-logger')

--- a/entry-cache/entry-cache-service.js
+++ b/entry-cache/entry-cache-service.js
@@ -2,10 +2,9 @@ var BASES = (process.env.BASES || process.argv[2] || '').split(',')
 
 require('seneca')({
   tag:'entry-cache',
-  log: 'silent',
+  internal: {logger: require('seneca-demo-logger')},
   debug: {short_logs:true}
 })
-  .use('demo-logger')
   .use('entry-cache-logic')
   .use('mesh',{
     pin: 'store:list,kind:entry,cache:*',

--- a/entry-store/entry-store-service.js
+++ b/entry-store/entry-store-service.js
@@ -4,9 +4,9 @@ require('seneca')({
   tag: 'entry-store',
   log: 'silent',
   legacy: { logging: false },
-  internal: { logger: require('seneca-demo-logger') },
   debug: {short_logs:true}
 })
+  .use('demo-logger')
   .use('basic')
   .use('entity')
   .use('entry-store-logic')

--- a/entry-store/entry-store-service.js
+++ b/entry-store/entry-store-service.js
@@ -2,10 +2,9 @@ var BASES = (process.env.BASES || process.argv[2] || '').split(',')
 
 require('seneca')({
   tag: 'entry-store',
-  log: 'silent',
+  internal: {logger: require('seneca-demo-logger')},
   debug: {short_logs:true}
 })
-  .use('demo-logger')
   .use('basic')
   .use('entity')
   .use('entry-store-logic')

--- a/entry-store/entry-store-service.js
+++ b/entry-store/entry-store-service.js
@@ -7,10 +7,11 @@ require('seneca')({
   internal: { logger: require('seneca-demo-logger') },
   debug: {short_logs:true}
 })
+  .use('basic')
   .use('entity')
   .use('entry-store-logic')
   .use('mesh',{
-    pin: 'store:*,kind:entry', 
+    pin: 'store:*,kind:entry',
     bases: BASES
   })
   .ready(function(){

--- a/entry-store/entry-store-service.js
+++ b/entry-store/entry-store-service.js
@@ -3,7 +3,6 @@ var BASES = (process.env.BASES || process.argv[2] || '').split(',')
 require('seneca')({
   tag: 'entry-store',
   log: 'silent',
-  legacy: { logging: false },
   debug: {short_logs:true}
 })
   .use('demo-logger')

--- a/fanout/fanout-service.js
+++ b/fanout/fanout-service.js
@@ -2,10 +2,9 @@ var BASES = (process.env.BASES || process.argv[2] || '').split(',')
 
 require('seneca')({
   tag: 'fanout',
-  log: 'silent',
+  internal: {logger: require('seneca-demo-logger')},
   debug: {short_logs:true}
 })
-  .use('demo-logger')
   .use('fanout-logic')
 
   .add('info:entry', function(msg,done){

--- a/fanout/fanout-service.js
+++ b/fanout/fanout-service.js
@@ -3,7 +3,6 @@ var BASES = (process.env.BASES || process.argv[2] || '').split(',')
 require('seneca')({
   tag: 'fanout',
   log: 'silent',
-  legacy: { logging: false },
   debug: {short_logs:true}
 })
   .use('demo-logger')

--- a/fanout/fanout-service.js
+++ b/fanout/fanout-service.js
@@ -4,9 +4,9 @@ require('seneca')({
   tag: 'fanout',
   log: 'silent',
   legacy: { logging: false },
-  internal: { logger: require('seneca-demo-logger') },
   debug: {short_logs:true}
 })
+  .use('demo-logger')
   .use('fanout-logic')
 
   .add('info:entry', function(msg,done){

--- a/follow/follow-service.js
+++ b/follow/follow-service.js
@@ -3,7 +3,6 @@ var BASES = (process.env.BASES || process.argv[2] || '').split(',')
 require('seneca')({
   tag: 'follow',
   log: 'silent',
-  legacy: { logging: false },
   debug: {short_logs:true}
 })
   .use('demo-logger')

--- a/follow/follow-service.js
+++ b/follow/follow-service.js
@@ -4,9 +4,9 @@ require('seneca')({
   tag: 'follow',
   log: 'silent',
   legacy: { logging: false },
-  internal: { logger: require('seneca-demo-logger') },
   debug: {short_logs:true}
 })
+  .use('demo-logger')
   .use('entity')
   .use('follow-logic')
   .use('mesh',{
@@ -25,7 +25,7 @@ require('seneca')({
 
     seneca.act('follow:user,user:f0,target:u0')
     seneca.act('follow:user,user:f1,target:u0')
-    
+
     setTimeout( function() {
       seneca.act('follow:list,kind:followers,user:u0', function(e,list){
         console.log('u0',list)

--- a/follow/follow-service.js
+++ b/follow/follow-service.js
@@ -2,10 +2,9 @@ var BASES = (process.env.BASES || process.argv[2] || '').split(',')
 
 require('seneca')({
   tag: 'follow',
-  log: 'silent',
+  internal: {logger: require('seneca-demo-logger')},
   debug: {short_logs:true}
 })
-  .use('demo-logger')
   .use('entity')
   .use('follow-logic')
   .use('mesh',{

--- a/home/home-service.js
+++ b/home/home-service.js
@@ -14,7 +14,7 @@ var Seneca     = require('seneca')
 
 var server = new hapi.Server()
 
-server.connection({ 
+server.connection({
   port: PORT
 })
 
@@ -22,15 +22,15 @@ server.register( vision )
 server.register( inert )
 
 server.register({
-  register:chairo, 
+  register:chairo,
   options:{
     seneca: Seneca({
       tag: 'home',
       log: 'silent',
       legacy: { logging: false },
-      internal: { logger: require('seneca-demo-logger') },
       debug: {short_logs:true}
     })
+    .use('demo-logger')
   }
 })
 
@@ -47,7 +47,7 @@ server.register({
   }
 })
 
-  
+
 server.views({
   engines: { html: handlebars },
   path: __dirname + '/www',
@@ -55,8 +55,8 @@ server.views({
 })
 
 
-server.route({ 
-  method: 'GET', path: '/{user}', 
+server.route({
+  method: 'GET', path: '/{user}',
   handler: function( req, reply )
   {
     server.seneca.act(

--- a/home/home-service.js
+++ b/home/home-service.js
@@ -26,10 +26,9 @@ server.register({
   options:{
     seneca: Seneca({
       tag: 'home',
-      log: 'silent',
+      internal: {logger: require('seneca-demo-logger')},
       debug: {short_logs:true}
     })
-    .use('demo-logger')
   }
 })
 

--- a/home/home-service.js
+++ b/home/home-service.js
@@ -27,7 +27,6 @@ server.register({
     seneca: Seneca({
       tag: 'home',
       log: 'silent',
-      legacy: { logging: false },
       debug: {short_logs:true}
     })
     .use('demo-logger')

--- a/index/index-service.js
+++ b/index/index-service.js
@@ -3,7 +3,6 @@ var BASES = (process.env.BASES || process.argv[2] || '').split(',')
 require('seneca')({
   tag: 'index',
   log: 'silent',
-  legacy: { logging: false },
   debug: {short_logs:true}
 })
   .use('demo-logger')

--- a/index/index-service.js
+++ b/index/index-service.js
@@ -4,9 +4,9 @@ require('seneca')({
   tag: 'index',
   log: 'silent',
   legacy: { logging: false },
-  internal: { logger: require('seneca-demo-logger') },
   debug: {short_logs:true}
 })
+  .use('demo-logger')
 
   .use('index-logic')
 

--- a/index/index-service.js
+++ b/index/index-service.js
@@ -2,10 +2,9 @@ var BASES = (process.env.BASES || process.argv[2] || '').split(',')
 
 require('seneca')({
   tag: 'index',
-  log: 'silent',
+  internal: {logger: require('seneca-demo-logger')},
   debug: {short_logs:true}
 })
-  .use('demo-logger')
 
   .use('index-logic')
 

--- a/mine/mine-service.js
+++ b/mine/mine-service.js
@@ -26,11 +26,10 @@ server.register({
   options:{
     seneca: Seneca({
       tag: 'mine',
-      log: 'silent',
+      internal: {logger: require('seneca-demo-logger')},
       debug: {short_logs:true}
     })
     .use('entity')
-    .use('demo-logger')
   }
 })
 

--- a/mine/mine-service.js
+++ b/mine/mine-service.js
@@ -14,7 +14,7 @@ var Seneca     = require('seneca')
 
 var server = new hapi.Server()
 
-server.connection({ 
+server.connection({
   port: PORT
 })
 
@@ -22,15 +22,16 @@ server.register( vision )
 server.register( inert )
 
 server.register({
-  register:chairo, 
+  register:chairo,
   options:{
     seneca: Seneca({
       tag: 'mine',
       log: 'silent',
       legacy: { logging: false },
-      internal: { logger: require('seneca-demo-logger') },
       debug: {short_logs:true}
-    }).use('entity')
+    })
+    .use('entity')
+    .use('demo-logger')
   }
 })
 
@@ -55,8 +56,8 @@ server.views({
 })
 
 
-server.route({ 
-  method: 'GET', path: '/mine/{user}', 
+server.route({
+  method: 'GET', path: '/mine/{user}',
   handler: function( req, reply )
   {
     server.seneca.act(

--- a/mine/mine-service.js
+++ b/mine/mine-service.js
@@ -27,7 +27,6 @@ server.register({
     seneca: Seneca({
       tag: 'mine',
       log: 'silent',
-      legacy: { logging: false },
       debug: {short_logs:true}
     })
     .use('entity')

--- a/package.json
+++ b/package.json
@@ -22,8 +22,8 @@
   "dependencies": {
     "chairo": "2.2.1",
     "handlebars": "4.0.5",
-    "hapi": "14.2.0",
-    "inert": "4.0.1",
+    "hapi": "15.0.3",
+    "inert": "4.0.2",
     "lodash": "4.15.0",
     "memdown": "1.2.0",
     "moment": "2.14.1",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "seneca": "2.1.0",
     "seneca-balance-client": "0.6.0",
     "seneca-entity": "1.3.0",
-    "seneca-mesh": "0.8.0",
+    "seneca-mesh": "0.9.0",
     "sneeze": "0.7.1",
     "vision": "4.1.0",
     "wo": "0.8.0",

--- a/package.json
+++ b/package.json
@@ -28,14 +28,16 @@
     "memdown": "1.2.0",
     "moment": "2.14.1",
     "search-index": "0.8.15",
-    "seneca": "2.1.0",
+    "seneca": "3.0.0",
     "seneca-balance-client": "0.6.0",
+    "seneca-basic": "^0.5.0",
+    "seneca-demo-logger": "0.1.0",
     "seneca-entity": "1.3.0",
     "seneca-mesh": "0.9.0",
+    "seneca-repl": "^0.3.0",
     "sneeze": "0.7.1",
     "vision": "4.1.0",
-    "wo": "0.8.0",
-    "seneca-demo-logger": "0.1.0"
+    "wo": "0.8.0"
   },
   "files": [
     "api/api.js"

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "search-index": "0.8.15",
     "seneca": "2.1.0",
     "seneca-balance-client": "0.6.0",
-    "seneca-entity": "1.2.0",
+    "seneca-entity": "1.3.0",
     "seneca-mesh": "0.8.0",
     "sneeze": "0.7.1",
     "vision": "4.1.0",

--- a/package.json
+++ b/package.json
@@ -30,11 +30,11 @@
     "search-index": "0.8.15",
     "seneca": "3.0.0",
     "seneca-balance-client": "0.6.0",
-    "seneca-basic": "^0.5.0",
+    "seneca-basic": "0.5.0",
     "seneca-demo-logger": "0.1.0",
     "seneca-entity": "1.3.0",
     "seneca-mesh": "0.9.0",
-    "seneca-repl": "^0.3.0",
+    "seneca-repl": "0.3.0",
     "sneeze": "0.7.1",
     "vision": "4.1.0",
     "wo": "0.8.0"

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "moment": "2.14.1",
     "search-index": "0.8.15",
     "seneca": "2.1.0",
-    "seneca-balance-client": "0.5.0",
+    "seneca-balance-client": "0.6.0",
     "seneca-entity": "1.2.0",
     "seneca-mesh": "0.8.0",
     "sneeze": "0.7.1",

--- a/post/post-service.js
+++ b/post/post-service.js
@@ -3,7 +3,6 @@ var BASES = (process.env.BASES || process.argv[2] || '').split(',')
 require('seneca')({
   tag: 'post',
   log: 'silent',
-  legacy: { logging: false },
   debug: { short_logs: true }
 })
   .use('demo-logger')

--- a/post/post-service.js
+++ b/post/post-service.js
@@ -2,10 +2,9 @@ var BASES = (process.env.BASES || process.argv[2] || '').split(',')
 
 require('seneca')({
   tag: 'post',
-  log: 'silent',
+  internal: {logger: require('seneca-demo-logger')},
   debug: { short_logs: true }
 })
-  .use('demo-logger')
   .use('entity')
   .use('post-logic')
 

--- a/post/post-service.js
+++ b/post/post-service.js
@@ -4,9 +4,9 @@ require('seneca')({
   tag: 'post',
   log: 'silent',
   legacy: { logging: false },
-  internal: { logger: require('seneca-demo-logger') },
   debug: { short_logs: true }
 })
+  .use('demo-logger')
   .use('entity')
   .use('post-logic')
 

--- a/repl/repl-service.js
+++ b/repl/repl-service.js
@@ -7,9 +7,9 @@ var seneca = require('seneca')({
   tag: 'repl',
   log: 'silent',
   legacy: { logging: false },
-  internal: { logger: require('seneca-demo-logger') },
   debug: {short_logs:true}
 })
+.use('demo-logger')
 .use('mesh',{
   tag: null, // ensures membership of all tagged meshes
   bases: BASES,

--- a/repl/repl-service.js
+++ b/repl/repl-service.js
@@ -1,30 +1,35 @@
 var REPL_PORT = parseInt(process.env.REPL_PORT || process.argv[2] || 10001)
 var BASES = (process.env.BASES || process.argv[3] || '').split(',')
 
-require('seneca')({
+var repl = require('seneca-repl');
+
+var seneca = require('seneca')({
   tag: 'repl',
   log: 'silent',
   legacy: { logging: false },
   internal: { logger: require('seneca-demo-logger') },
   debug: {short_logs:true}
 })
-  .use('mesh',{
-    tag: null, // ensures membership of all tagged meshes
-    bases: BASES,
-    make_entry: function( entry ) {
-      if( 'wo' === entry.tag$ ) {
-        return {
-          route: JSON.stringify(entry.route),
-          host: entry.host,
-          port: entry.port,
-          identifier: entry.identifier$
-        }
+.use('mesh',{
+  tag: null, // ensures membership of all tagged meshes
+  bases: BASES,
+  make_entry: function( entry ) {
+    if( 'wo' === entry.tag$ ) {
+      return {
+        route: JSON.stringify(entry.route),
+        host: entry.host,
+        port: entry.port,
+        identifier: entry.identifier$
       }
     }
-  })
-  .repl({
+  }
+})
+.use(repl)
+.ready(function () {
+  seneca.repl({
     port: REPL_PORT,
     alias: {
-      m: 'role:mesh,get:members'      
+      m: 'role:mesh,get:members'
     }
   })
+})

--- a/repl/repl-service.js
+++ b/repl/repl-service.js
@@ -6,7 +6,6 @@ var repl = require('seneca-repl');
 var seneca = require('seneca')({
   tag: 'repl',
   log: 'silent',
-  legacy: { logging: false },
   debug: {short_logs:true}
 })
 .use('demo-logger')

--- a/repl/repl-service.js
+++ b/repl/repl-service.js
@@ -5,10 +5,9 @@ var repl = require('seneca-repl');
 
 var seneca = require('seneca')({
   tag: 'repl',
-  log: 'silent',
+  internal: {logger: require('seneca-demo-logger')},
   debug: {short_logs:true}
 })
-.use('demo-logger')
 .use('mesh',{
   tag: null, // ensures membership of all tagged meshes
   bases: BASES,

--- a/search/search-service.js
+++ b/search/search-service.js
@@ -27,7 +27,6 @@ server.register({
     seneca: Seneca({
       tag: 'search',
       log: 'silent',
-      legacy: { logging: false },
       debug: {short_logs:true}
     })
     .use('demo-logger')

--- a/search/search-service.js
+++ b/search/search-service.js
@@ -26,10 +26,9 @@ server.register({
   options:{
     seneca: Seneca({
       tag: 'search',
-      log: 'silent',
+      internal: {logger: require('seneca-demo-logger')},
       debug: {short_logs:true}
     })
-    .use('demo-logger')
   }
 })
 

--- a/search/search-service.js
+++ b/search/search-service.js
@@ -14,7 +14,7 @@ var Seneca     = require('seneca')
 
 var server = new hapi.Server()
 
-server.connection({ 
+server.connection({
   port: PORT
 })
 
@@ -22,15 +22,15 @@ server.register( vision )
 server.register( inert )
 
 server.register({
-  register:chairo, 
+  register:chairo,
   options:{
     seneca: Seneca({
       tag: 'search',
       log: 'silent',
       legacy: { logging: false },
-      internal: { logger: require('seneca-demo-logger') },
       debug: {short_logs:true}
     })
+    .use('demo-logger')
   }
 })
 
@@ -55,12 +55,12 @@ server.views({
 })
 
 
-server.route({ 
-  method: ['GET','POST'], 
-  path: '/search/{user}', 
+server.route({
+  method: ['GET','POST'],
+  path: '/search/{user}',
   handler: function( req, reply )
   {
-    var query 
+    var query
       = (req.query ? (null == req.query.query ? '' : ' '+req.query.query) : '')
       + (req.payload ? (null == req.payload.query ? '' : ' '+req.payload.query) : '')
 
@@ -89,8 +89,8 @@ server.route({
               user: req.params.user,
               entrylist: _.map(entrylist,function(entry){
                 entry.when = moment(entry.when).fromNow()
-                entry.can_follow = 
-                  req.params.user != entry.user && 
+                entry.can_follow =
+                  req.params.user != entry.user &&
                   !_.includes(following,entry.user)
                 return entry
               })

--- a/timeline/timeline-service.js
+++ b/timeline/timeline-service.js
@@ -3,10 +3,9 @@ var BASES = (process.env.BASES || process.argv[3] || '').split(',')
 
 require('seneca')({
   tag: 'timeline'+SHARD,
-  log: 'silent',
+  internal: {logger: require('seneca-demo-logger')},
   debug: {short_logs:true}
 })
-  .use('demo-logger')
   .use('entity')
   .use('timeline-logic')
   .use('mesh',{

--- a/timeline/timeline-service.js
+++ b/timeline/timeline-service.js
@@ -5,9 +5,9 @@ require('seneca')({
   tag: 'timeline'+SHARD,
   log: 'silent',
   legacy: { logging: false },
-  internal: { logger: require('seneca-demo-logger') },
   debug: {short_logs:true}
 })
+  .use('demo-logger')
   .use('entity')
   .use('timeline-logic')
   .use('mesh',{

--- a/timeline/timeline-service.js
+++ b/timeline/timeline-service.js
@@ -4,7 +4,6 @@ var BASES = (process.env.BASES || process.argv[3] || '').split(',')
 require('seneca')({
   tag: 'timeline'+SHARD,
   log: 'silent',
-  legacy: { logging: false },
   debug: {short_logs:true}
 })
   .use('demo-logger')

--- a/timeline/timeline-shard-service.js
+++ b/timeline/timeline-shard-service.js
@@ -10,9 +10,10 @@ require('seneca')({
   tag: 'timeline-shard',
   log: 'silent',
   legacy: { logging: false },
-  internal: { logger: require('seneca-demo-logger') },
   debug: {short_logs:true}
 })
+
+  .use('demo-logger')
 
   .add('timeline:list',function(msg,done){
     var shard = resolve_shard(msg.user)

--- a/timeline/timeline-shard-service.js
+++ b/timeline/timeline-shard-service.js
@@ -9,7 +9,6 @@ function resolve_shard(user) {
 require('seneca')({
   tag: 'timeline-shard',
   log: 'silent',
-  legacy: { logging: false },
   debug: {short_logs:true}
 })
 

--- a/timeline/timeline-shard-service.js
+++ b/timeline/timeline-shard-service.js
@@ -8,11 +8,9 @@ function resolve_shard(user) {
 
 require('seneca')({
   tag: 'timeline-shard',
-  log: 'silent',
+  internal: {logger: require('seneca-demo-logger')},
   debug: {short_logs:true}
 })
-
-  .use('demo-logger')
 
   .add('timeline:list',function(msg,done){
     var shard = resolve_shard(msg.user)


### PR DESCRIPTION
This builds on top of https://github.com/senecajs/ramanujan/pull/7

In includes update to all seneca related dependencies and upgrade to seneca 3.
Only three major changes where necessary to make the project work:
- add seneca-basic (that isn't included by default in seneca 3 but is required by seneca-men-store for generate_id)
- add seneca-repl (that was devoted to its own plugin)
- start the repl after login initialisation completed (ready event)
