### PR TITLE
Add zipkin tracer and standard http transport

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,11 @@ for peer-to-peer service discovery. A service registry is not needed
 as the network automatically reconfigures as microservices are added
 and removed.
 
+A version with the standard http transport is provided
+through the use of `MESH=false` environment variable.
+
+This will also enable the seneca-zipkin-tracer that at the moment isn't compatible with seneca-mesh
+
 ## Scope of the system
 
 The system shows implementations of some of the essential features of

--- a/api/api-service.js
+++ b/api/api-service.js
@@ -2,6 +2,7 @@
 
 var PORT = process.env.PORT || process.argv[2] || 0
 var BASES = (process.env.BASES || process.argv[3] || '').split(',')
+var MESH = process.env.MESH ? process.env.MESH === 'true' : true
 
 var Hapi   = require('hapi')
 var Chairo = require('chairo')
@@ -83,7 +84,10 @@ server.seneca
   .add('role:api,cmd:ping', function(msg,done){
     done( null, {pong:true,api:true,time:Date.now()})
   })
-  .use('../transport-config/transport-config',{bases:BASES})
+  .use('../transport-config/transport-config',{
+    mesh: MESH,
+    bases: BASES
+  })
 
 server.start(function(){
   console.log('api',server.info.host,server.info.port)

--- a/api/api-service.js
+++ b/api/api-service.js
@@ -83,7 +83,7 @@ server.seneca
   .add('role:api,cmd:ping', function(msg,done){
     done( null, {pong:true,api:true,time:Date.now()})
   })
-  .use('mesh',{bases:BASES})
+  .use('../transport-config/transport-config',{bases:BASES})
 
 server.start(function(){
   console.log('api',server.info.host,server.info.port)

--- a/entry-cache/entry-cache-service.js
+++ b/entry-cache/entry-cache-service.js
@@ -6,7 +6,7 @@ require('seneca')({
   debug: {short_logs:true}
 })
   .use('entry-cache-logic')
-  .use('mesh',{
+  .use('../transport-config/transport-config',{
     pin: 'store:list,kind:entry,cache:*',
     bases: BASES
   })

--- a/entry-cache/entry-cache-service.js
+++ b/entry-cache/entry-cache-service.js
@@ -1,4 +1,5 @@
 var BASES = (process.env.BASES || process.argv[2] || '').split(',')
+var MESH = process.env.MESH ? process.env.MESH === 'true' : true
 
 require('seneca')({
   tag:'entry-cache',
@@ -6,7 +7,8 @@ require('seneca')({
   debug: {short_logs:true}
 })
   .use('entry-cache-logic')
-  .use('../transport-config/transport-config',{
+  .use('../transport-config/transport-config', {
+    mesh: MESH,
     pin: 'store:list,kind:entry,cache:*',
     bases: BASES
   })

--- a/entry-store/entry-store-logic.js
+++ b/entry-store/entry-store-logic.js
@@ -15,8 +15,8 @@ module.exports = function entry_store (options) {
         {
           timeline: 'insert',
           users: [msg.user],
-        }, 
-        entry, 
+        },
+        entry,
         function(err) {
           return done(err, entry)
         })

--- a/entry-store/entry-store-service.js
+++ b/entry-store/entry-store-service.js
@@ -1,4 +1,5 @@
 var BASES = (process.env.BASES || process.argv[2] || '').split(',')
+var MESH = process.env.MESH ? process.env.MESH === 'true' : true
 
 require('seneca')({
   tag: 'entry-store',
@@ -9,6 +10,7 @@ require('seneca')({
   .use('entity')
   .use('entry-store-logic')
   .use('../transport-config/transport-config',{
+    mesh: MESH,
     pin: 'store:*,kind:entry',
     bases: BASES
   })

--- a/entry-store/entry-store-service.js
+++ b/entry-store/entry-store-service.js
@@ -8,7 +8,7 @@ require('seneca')({
   .use('basic')
   .use('entity')
   .use('entry-store-logic')
-  .use('mesh',{
+  .use('../transport-config/transport-config',{
     pin: 'store:*,kind:entry',
     bases: BASES
   })

--- a/fanout/fanout-service.js
+++ b/fanout/fanout-service.js
@@ -7,12 +7,7 @@ require('seneca')({
 })
   .use('fanout-logic')
 
-  .add('info:entry', function(msg,done){
-    delete msg.info
-    this.act('fanout:entry',msg,done)
-  })
-
-  .use('mesh',{
+  .use('../transport-config/transport-config',{
     listen:[
       {pin: 'fanout:*'},
       {pin: 'info:entry', model:'observe'}
@@ -21,6 +16,12 @@ require('seneca')({
   })
 
   .ready(function(){
+    this.add('info:entry', function(msg,done){
+      console.log('info:entry ricevuto da fanout')
+      delete msg.info
+      this.act('fanout:entry',msg,done)
+    })
+
     console.log(this.id)
   })
 

--- a/fanout/fanout-service.js
+++ b/fanout/fanout-service.js
@@ -1,4 +1,5 @@
 var BASES = (process.env.BASES || process.argv[2] || '').split(',')
+var MESH = process.env.MESH ? process.env.MESH === 'true' : true
 
 require('seneca')({
   tag: 'fanout',
@@ -8,6 +9,7 @@ require('seneca')({
   .use('fanout-logic')
 
   .use('../transport-config/transport-config',{
+    mesh: MESH,
     listen:[
       {pin: 'fanout:*'},
       {pin: 'info:entry', model:'observe'}

--- a/follow/follow-service.js
+++ b/follow/follow-service.js
@@ -7,7 +7,7 @@ require('seneca')({
 })
   .use('entity')
   .use('follow-logic')
-  .use('mesh',{
+  .use('../transport-config/transport-config',{
     pin: 'follow:*',
     bases: BASES
   })

--- a/follow/follow-service.js
+++ b/follow/follow-service.js
@@ -1,4 +1,5 @@
 var BASES = (process.env.BASES || process.argv[2] || '').split(',')
+var MESH = process.env.MESH ? process.env.MESH === 'true' : true
 
 require('seneca')({
   tag: 'follow',
@@ -8,6 +9,7 @@ require('seneca')({
   .use('entity')
   .use('follow-logic')
   .use('../transport-config/transport-config',{
+    mesh: MESH,
     pin: 'follow:*',
     bases: BASES
   })

--- a/home/home-service.js
+++ b/home/home-service.js
@@ -76,8 +76,7 @@ server.route({
   }
 })
 
-
-server.seneca.use('mesh',{bases:BASES})
+server.seneca.use('../transport-config/transport-config',{bases:BASES})
 
 server.start(function(){
   console.log('home',server.info.host,server.info.port)

--- a/home/home-service.js
+++ b/home/home-service.js
@@ -2,6 +2,7 @@
 
 var PORT = process.env.PORT || process.argv[2] || 0
 var BASES = (process.env.BASES || process.argv[3] || '').split(',')
+var MESH = process.env.MESH ? process.env.MESH === 'true' : true
 
 var hapi       = require('hapi')
 var chairo     = require('chairo')
@@ -76,7 +77,10 @@ server.route({
   }
 })
 
-server.seneca.use('../transport-config/transport-config',{bases:BASES})
+server.seneca.use('../transport-config/transport-config',{
+  mesh: MESH,
+  bases:BASES
+})
 
 server.start(function(){
   console.log('home',server.info.host,server.info.port)

--- a/index/index-service.js
+++ b/index/index-service.js
@@ -8,12 +8,7 @@ require('seneca')({
 
   .use('index-logic')
 
-  .add('info:entry', function(msg,done){
-    delete msg.info
-    this.act('search:insert',msg,done)
-  })
-
-  .use('mesh',{
+  .use('../transport-config/transport-config',{
     listen:[
       {pin: 'search:*'},
       {pin: 'info:entry', model:'observe'}
@@ -22,5 +17,10 @@ require('seneca')({
   })
 
   .ready(function(){
+    this.add('info:entry', function(msg,done){
+      delete msg.info
+      this.act('search:insert',msg,done)
+    })
+
     console.log(this.id)
   })

--- a/index/index-service.js
+++ b/index/index-service.js
@@ -1,4 +1,5 @@
 var BASES = (process.env.BASES || process.argv[2] || '').split(',')
+var MESH = process.env.MESH ? process.env.MESH === 'true' : true
 
 require('seneca')({
   tag: 'index',
@@ -9,6 +10,7 @@ require('seneca')({
   .use('index-logic')
 
   .use('../transport-config/transport-config',{
+    mesh: MESH,
     listen:[
       {pin: 'search:*'},
       {pin: 'info:entry', model:'observe'}

--- a/mine/mine-service.js
+++ b/mine/mine-service.js
@@ -2,6 +2,7 @@
 
 var PORT = process.env.PORT || process.argv[2] || 0
 var BASES = (process.env.BASES || process.argv[3] || '').split(',')
+var MESH = process.env.MESH ? process.env.MESH === 'true' : true
 
 var hapi       = require('hapi')
 var chairo     = require('chairo')
@@ -30,7 +31,6 @@ server.register({
       debug: {short_logs:true}
     })
     .use('entity')
-    .use('../transport-config/transport-config')
   }
 })
 
@@ -79,7 +79,10 @@ server.route({
 })
 
 
-server.seneca.use('../transport-config/transport-config',{bases:BASES})
+server.seneca.use('../transport-config/transport-config',{
+  mesh: MESH,
+  bases:BASES
+})
 
 server.start(function(){
   console.log('mine',server.info.host,server.info.port)

--- a/mine/mine-service.js
+++ b/mine/mine-service.js
@@ -30,6 +30,7 @@ server.register({
       debug: {short_logs:true}
     })
     .use('entity')
+    .use('../transport-config/transport-config')
   }
 })
 
@@ -78,7 +79,7 @@ server.route({
 })
 
 
-server.seneca.use('mesh',{bases:BASES})
+server.seneca.use('../transport-config/transport-config',{bases:BASES})
 
 server.start(function(){
   console.log('mine',server.info.host,server.info.port)

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "sneeze": "0.7.1",
     "vision": "4.1.0",
     "wo": "0.8.0",
-    "seneca-zipkin-tracer": "git@github.com:paolochiodi/seneca-zipkin-tracer.git"
+    "seneca-zipkin-tracer": "https://github.com/paolochiodi/seneca-zipkin-tracer.git"
   },
   "files": [
     "api/api.js"

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "seneca-repl": "0.3.0",
     "sneeze": "0.7.1",
     "vision": "4.1.0",
-    "wo": "0.8.0"
+    "wo": "0.8.0",
+    "seneca-zipkin-tracer": "git@github.com:paolochiodi/seneca-zipkin-tracer.git"
   },
   "files": [
     "api/api.js"

--- a/post/post-service.js
+++ b/post/post-service.js
@@ -1,4 +1,5 @@
 var BASES = (process.env.BASES || process.argv[2] || '').split(',')
+var MESH = process.env.MESH ? process.env.MESH === 'true' : true
 
 require('seneca')({
   tag: 'post',
@@ -8,6 +9,7 @@ require('seneca')({
   .use('entity')
   .use('post-logic')
   .use('../transport-config/transport-config',{
+    mesh: MESH,
     pin: 'post:*',
     bases: BASES
   })

--- a/post/post-service.js
+++ b/post/post-service.js
@@ -7,8 +7,7 @@ require('seneca')({
 })
   .use('entity')
   .use('post-logic')
-
-  .use('mesh',{
+  .use('../transport-config/transport-config',{
     pin: 'post:*',
     bases: BASES
   })

--- a/repl/repl-service.js
+++ b/repl/repl-service.js
@@ -1,5 +1,6 @@
 var REPL_PORT = parseInt(process.env.REPL_PORT || process.argv[2] || 10001)
 var BASES = (process.env.BASES || process.argv[3] || '').split(',')
+var MESH = process.env.MESH ? process.env.MESH === 'true' : true
 
 var repl = require('seneca-repl')
 
@@ -9,6 +10,7 @@ var seneca = require('seneca')({
   debug: {short_logs:true}
 })
 .use('../transport-config/transport-config',{
+  mesh: MESH,
   tag: null, // ensures membership of all tagged meshes
   bases: BASES,
   make_entry: function( entry ) {

--- a/repl/repl-service.js
+++ b/repl/repl-service.js
@@ -1,14 +1,14 @@
 var REPL_PORT = parseInt(process.env.REPL_PORT || process.argv[2] || 10001)
 var BASES = (process.env.BASES || process.argv[3] || '').split(',')
 
-var repl = require('seneca-repl');
+var repl = require('seneca-repl')
 
 var seneca = require('seneca')({
   tag: 'repl',
   internal: {logger: require('seneca-demo-logger')},
   debug: {short_logs:true}
 })
-.use('mesh',{
+.use('../transport-config/transport-config',{
   tag: null, // ensures membership of all tagged meshes
   bases: BASES,
   make_entry: function( entry ) {

--- a/search/search-service.js
+++ b/search/search-service.js
@@ -99,7 +99,7 @@ server.route({
 })
 
 
-server.seneca.use('mesh',{bases:BASES})
+server.seneca.use('../transport-config/transport-config',{bases:BASES})
 
 server.start(function(){
   console.log('search',server.info.uri)

--- a/search/search-service.js
+++ b/search/search-service.js
@@ -2,6 +2,7 @@
 
 var PORT = process.env.PORT || process.argv[2] || 0
 var BASES = (process.env.BASES || process.argv[3] || '').split(',')
+var MESH = process.env.MESH ? process.env.MESH === 'true' : true
 
 var hapi       = require('hapi')
 var chairo     = require('chairo')
@@ -99,7 +100,10 @@ server.route({
 })
 
 
-server.seneca.use('../transport-config/transport-config',{bases:BASES})
+server.seneca.use('../transport-config/transport-config',{
+  mesh: MESH,
+  bases:BASES
+})
 
 server.start(function(){
   console.log('search',server.info.uri)

--- a/timeline/timeline-service.js
+++ b/timeline/timeline-service.js
@@ -8,7 +8,7 @@ require('seneca')({
 })
   .use('entity')
   .use('timeline-logic')
-  .use('mesh',{
+  .use('../transport-config/transport-config', {
     //pin: 'timeline:*',
     pin: 'timeline:*,shard:'+SHARD,
     bases: BASES

--- a/timeline/timeline-service.js
+++ b/timeline/timeline-service.js
@@ -1,5 +1,6 @@
 var SHARD = process.env.SHARD || process.argv[2] || 0
 var BASES = (process.env.BASES || process.argv[3] || '').split(',')
+var MESH = process.env.MESH ? process.env.MESH === 'true' : true
 
 require('seneca')({
   tag: 'timeline'+SHARD,
@@ -9,6 +10,7 @@ require('seneca')({
   .use('entity')
   .use('timeline-logic')
   .use('../transport-config/transport-config', {
+    mesh: MESH,
     //pin: 'timeline:*',
     pin: 'timeline:*,shard:'+SHARD,
     bases: BASES

--- a/timeline/timeline-shard-service.js
+++ b/timeline/timeline-shard-service.js
@@ -1,4 +1,5 @@
 var BASES = (process.env.BASES || process.argv[2] || '').split(',')
+var MESH = process.env.MESH ? process.env.MESH === 'true' : true
 
 var _ = require('lodash')
 
@@ -37,6 +38,7 @@ require('seneca')({
   })
 
   .use('../transport-config/transport-config',{
+    mesh: MESH,
     pin: 'timeline:*',
     bases: BASES
   })

--- a/timeline/timeline-shard-service.js
+++ b/timeline/timeline-shard-service.js
@@ -11,7 +11,6 @@ require('seneca')({
   internal: {logger: require('seneca-demo-logger')},
   debug: {short_logs:true}
 })
-
   .add('timeline:list',function(msg,done){
     var shard = resolve_shard(msg.user)
     this.act({shard:shard},msg,done)
@@ -37,7 +36,7 @@ require('seneca')({
     })
   })
 
-  .use('mesh',{
+  .use('../transport-config/transport-config',{
     pin: 'timeline:*',
     bases: BASES
   })

--- a/transport-config/transport-config.js
+++ b/transport-config/transport-config.js
@@ -98,8 +98,6 @@ function listen (seneca, config) {
 function override_pins (seneca, override_map) {
   Object.keys(override_map).forEach(function (pin) {
     seneca.add(pin, {strict$: {add: true}}, function (msg, done) {
-      console.log('dentro override')
-
       for (var i = 0; i < override_map[pin].length; i++) {
         routed_msg = Object.create(msg)
         routed_msg.for = override_map[pin][i];

--- a/transport-config/transport-config.js
+++ b/transport-config/transport-config.js
@@ -1,0 +1,142 @@
+
+var USE_MESH = false
+var NETWORK_CONFIGURATION = {
+  'entry-cache': {
+    port: 3101,
+    pin: 'store:list,kind:entry,cache:*'
+  },
+  'entry-store': {
+    port: 3102,
+    pin: 'store:*,kind:entry'
+  },
+  fanout: {
+    port: 3103,
+    listen:[
+      {pin: 'fanout:*'},
+      {pin: 'info:entry', model:'observe'}
+    ]
+  },
+  follow: {
+    port: 3104,
+    pin: 'follow:*'
+  },
+  index: {
+    port: 3105,
+    listen: [
+      {pin: 'search:*'},
+      {pin: 'info:entry', model:'observe'}
+    ]
+  },
+  post: {
+    port: 3106,
+    pin: 'post:*'
+  },
+  'timeline-shard': {
+    port: 3107,
+    pin: 'timeline:*'
+  },
+  timeline0: {
+    port: 3108,
+    pin: 'timeline:*,shard:0'
+  },
+  timeline1: {
+    port: 3109,
+    pin: 'timeline:*,shard:1'
+  }
+}
+
+function client(seneca, service_name, config, pins_to_override) {
+  var opts = {
+    port: config.port
+  }
+
+  if (config.pin) {
+    opts.pin = config.pin
+    seneca.client(opts)
+    return
+  }
+
+  if (!config.listen) {
+    return
+  }
+
+  opts.pins = []
+
+  config.listen.forEach(function (i) {
+    if (i.model === 'observe') {
+      opts.pins.push(i.pin + ',for:' + service_name)
+      pins_to_override[i.pin] = pins_to_override[i.pin] || []
+      pins_to_override[i.pin].push(service_name)
+    }
+    else {
+      opts.pins.push(i.pin)
+    }
+  })
+
+  seneca.client(opts)
+}
+
+function pickPin(value) {
+  return value.pin
+}
+
+function listen (seneca, config) {
+  var opts = {
+    port: config.port,
+  }
+
+  if (config.pin) {
+    opts.pin = config.pin
+  }
+
+  if (config.listen) {
+    opts.pins = config.listen.map(pickPin)
+  }
+
+  seneca.listen(opts)
+}
+
+function override_pins (seneca, override_map) {
+  Object.keys(override_map).forEach(function (pin) {
+    seneca.add(pin, {strict$: {add: true}}, function (msg, done) {
+      console.log('dentro override')
+
+      for (var i = 0; i < override_map[pin].length; i++) {
+        routed_msg = Object.create(msg)
+        routed_msg.for = override_map[pin][i];
+        this.act(pin + ',for:' + override_map[pin][i], msg)
+      }
+      done()
+    })
+  })
+}
+
+function transport_config_plugin (opts) {
+  var seneca = this.root;
+  var current_service = seneca.private$.optioner.get().tag
+
+  if (USE_MESH) {
+    seneca.use('mesh', opts)
+    return
+  }
+
+  seneca.use('zipkin-tracer')
+
+  var service
+  var config
+  var pins_to_override = {}
+
+  for (service in NETWORK_CONFIGURATION) {
+    config = NETWORK_CONFIGURATION[service]
+    if (service === current_service) {
+      listen(seneca, config)
+      continue
+    }
+
+    client(seneca, service, config, pins_to_override)
+  }
+
+  override_pins(this, pins_to_override)
+}
+
+module.exports = transport_config_plugin

--- a/transport-config/transport-config.js
+++ b/transport-config/transport-config.js
@@ -1,5 +1,4 @@
 
-var USE_MESH = false
 var NETWORK_CONFIGURATION = {
   'entry-cache': {
     port: 3101,
@@ -115,11 +114,14 @@ function transport_config_plugin (opts) {
   var seneca = this.root;
   var current_service = seneca.private$.optioner.get().tag
 
-  if (USE_MESH) {
+  if (opts.mesh) {
+    seneca.log.debug('transport_config using mesh')
+    delete opts.mesh
     seneca.use('mesh', opts)
     return
   }
 
+  seneca.log.debug('transport_config using http transport')
   seneca.use('zipkin-tracer')
 
   var service


### PR DESCRIPTION
The standard http transport is optional and is required in order to use
the zipking tracer because the current version conflict with seneca-mesh.

I still need to make USE_MESH and env variable, update package.json to point to a published package and possibly update the README, but I think this is still valuable to give @rjrodger a taste of the current solution
